### PR TITLE
[Discover][Traces] Assert RED metrics charts render without errors in e2e tests

### DIFF
--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/traces_experience/page_objects/charts.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/traces_experience/page_objects/charts.ts
@@ -15,6 +15,7 @@ export interface TracesCharts {
   readonly redMetricsCharts: Locator;
   readonly expectedTitles: readonly string[];
   getChartTitle(title: string): Locator;
+  getChartError(title: string): Locator;
 }
 
 export function createTracesCharts(page: ScoutPage): TracesCharts {
@@ -24,5 +25,12 @@ export function createTracesCharts(page: ScoutPage): TracesCharts {
     redMetricsCharts,
     expectedTitles: RED_METRICS_CHART_TITLES,
     getChartTitle: (title: string): Locator => redMetricsCharts.getByText(title),
+    getChartError: (title: string): Locator => {
+      const headingTestSubj = `embeddablePanelHeading-${title.replace(/\s/g, '')}`;
+      return redMetricsCharts
+        .locator('[data-test-subj="embeddablePanel"]')
+        .filter({ has: page.testSubj.locator(headingTestSubj) })
+        .locator('[data-test-subj="embeddable-lens-failure"]');
+    },
   };
 }

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/red_metrics_charts.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/red_metrics_charts.spec.ts
@@ -48,6 +48,7 @@ spaceTest.describe(
 
         for (const title of charts.expectedTitles) {
           await expect(charts.getChartTitle(title)).toBeVisible();
+          await expect(charts.getChartError(title)).toBeHidden();
         }
       });
     });
@@ -66,6 +67,7 @@ spaceTest.describe(
 
         for (const title of charts.expectedTitles) {
           await expect(charts.getChartTitle(title)).toBeVisible();
+          await expect(charts.getChartError(title)).toBeHidden();
         }
       });
     });


### PR DESCRIPTION
## Summary

Adds error-state assertions to the RED metrics charts e2e tests in the Discover traces experience, on top of #259906.

The existing tests only checked that charts were *visible*, but a chart can be visible while showing a Lens error (e.g. due to a broken ES|QL query or missing variables). This adds a `getChartError` helper to the charts page object that scopes `embeddable-lens-failure` to a specific chart panel by title, and asserts it is hidden for each RED metrics chart in the two positive render tests.

## Changes

- **`charts.ts`** — Added `getChartError(title)` to `TracesCharts` interface and implementation, scoped via `embeddablePanelHeading-{Title}` to find the error state within the correct panel
- **`red_metrics_charts.spec.ts`** — Added `getChartError` assertion alongside the existing visibility check in the ESQL and WHERE filter tests
