### PR TITLE
Provide a generic way to set chart adapter

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_experience_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_experience_grid.tsx
@@ -7,9 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { keys } from '@elastic/eui';
 import { usePerformanceContext } from '@kbn/ebt-tools';
+import { RequestAdapter } from '@kbn/inspector-plugin/common';
 import { useFetchMetricsData } from './hooks/use_fetch_metrics_data';
 import { METRICS_BREAKDOWN_SELECTOR_DATA_TEST_SUBJ } from '../../../common/constants';
 import { useMetricsExperienceState } from './context/metrics_experience_state_provider';
@@ -34,10 +35,19 @@ export const MetricsExperienceGrid = ({
   fetch$: discoverFetch$,
   fetchParams,
   isComponentVisible,
-  metricsRequestAdapter,
+  setLensRequestAdapter,
   breakdownField,
   onBreakdownFieldChange,
 }: UnifiedMetricsGridProps) => {
+  const metricsRequestAdapter = useMemo(() => new RequestAdapter(), []);
+
+  useEffect(() => {
+    setLensRequestAdapter?.(metricsRequestAdapter);
+    return () => {
+      setLensRequestAdapter?.(undefined);
+    };
+  }, [setLensRequestAdapter, metricsRequestAdapter]);
+
   const {
     searchTerm,
     isFullscreen,

--- a/src/platform/packages/shared/kbn-unified-histogram/hooks/use_services_bootstrap.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/hooks/use_services_bootstrap.ts
@@ -143,7 +143,14 @@ export const useServicesBootstrap = (
         lensVisServiceState: updatedLensVisServiceState,
       });
     },
-    ...pick(stateService, 'state$', 'setChartHidden', 'setTopPanelHeight', 'setTotalHits'),
+    ...pick(
+      stateService,
+      'state$',
+      'setChartHidden',
+      'setTopPanelHeight',
+      'setTotalHits',
+      'setLensRequestAdapter'
+    ),
   }));
 
   const stateProps = useStateProps({

--- a/src/platform/packages/shared/kbn-unified-histogram/hooks/use_unified_histogram.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/hooks/use_unified_histogram.ts
@@ -74,7 +74,7 @@ export type UnifiedHistogramApi = {
   fetch: (params: UnifiedHistogramFetchParamsExternal) => void;
 } & Pick<
   UnifiedHistogramStateService,
-  'state$' | 'setChartHidden' | 'setTopPanelHeight' | 'setTotalHits'
+  'state$' | 'setChartHidden' | 'setTopPanelHeight' | 'setTotalHits' | 'setLensRequestAdapter'
 >;
 
 export type UnifiedHistogramPartialLayoutProps = Omit<

--- a/src/platform/packages/shared/kbn-unified-histogram/mocks.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/mocks.ts
@@ -19,6 +19,7 @@ export const createMockUnifiedHistogramApi = () => {
     setChartHidden: jest.fn(),
     setTopPanelHeight: jest.fn(),
     setTotalHits: jest.fn(),
+    setLensRequestAdapter: jest.fn(),
     fetch: jest.fn(),
   };
   return api;

--- a/src/platform/packages/shared/kbn-unified-histogram/types.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/types.ts
@@ -323,8 +323,9 @@ export interface ChartSectionProps {
    */
   isComponentVisible: boolean;
   /**
-   * Optional request adapter for recording metrics-specific requests (e.g. METRICS_INFO)
-   * in the Inspector. When provided, the metrics experience will log its requests on this adapter.
+   * Optional callback for registering a request adapter for custom chart section requests
+   * in the Inspector. When called, the adapter will be synced to
+   * inspectorAdapters.lensRequests via the unified histogram state service.
    */
-  metricsRequestAdapter?: RequestAdapter;
+  setLensRequestAdapter?: (adapter: RequestAdapter | undefined) => void;
 }

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
@@ -17,7 +17,6 @@ import React, {
 } from 'react';
 import { createHtmlPortalNode, type HtmlPortalNode, InPortal } from 'react-reverse-portal';
 import type { UnifiedHistogramPartialLayoutProps } from '@kbn/unified-histogram';
-import { RequestAdapter } from '@kbn/inspector-plugin/common';
 import { UnifiedHistogramChart, useUnifiedHistogram } from '@kbn/unified-histogram';
 import { useChartStyles } from '@kbn/unified-histogram/components/chart/hooks/use_chart_styles';
 import { useServicesBootstrap } from '@kbn/unified-histogram/hooks/use_services_bootstrap';
@@ -38,7 +37,6 @@ import {
   useCurrentTabAction,
   internalStateActions,
   useRuntimeStateManager,
-  useCurrentTabDataStateContainer,
 } from '../../state_management/redux';
 import { ScopedServicesProvider } from '../../../../components/scoped_services_provider';
 import { useUnifiedHistogramRuntimeState } from './use_unified_histogram_runtime_state';
@@ -293,16 +291,6 @@ const CustomChartSectionWrapper = ({
     !!layoutProps.chart && !layoutProps.chart.hidden
   );
 
-  const dataStateContainer = useCurrentTabDataStateContainer();
-  const metricsRequestAdapter = useMemo(() => new RequestAdapter(), []);
-
-  useEffect(() => {
-    dataStateContainer.inspectorAdapters.lensRequests = metricsRequestAdapter;
-    return () => {
-      dataStateContainer.inspectorAdapters.lensRequests = undefined;
-    };
-  }, [dataStateContainer, metricsRequestAdapter]);
-
   if (!fetchParams || !hasValidFetchParams) {
     return null;
   }
@@ -323,7 +311,7 @@ const CustomChartSectionWrapper = ({
         fetchParams,
         isComponentVisible,
         ...unifiedHistogramProps,
-        metricsRequestAdapter,
+        setLensRequestAdapter: api.setLensRequestAdapter,
         initialState: metricsGridState,
         onInitialStateChange,
       })}


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
